### PR TITLE
fix stoploss and take profit orders 

### DIFF
--- a/rabbitx/client/endpoints/order.py
+++ b/rabbitx/client/endpoints/order.py
@@ -13,8 +13,8 @@ class OrderType(enum.Enum):
 
     MARKET = 'market'
     LIMIT = 'limit'
-    STOP_LOSS = 'stop_loss'
-    TAKE_PROFIT = 'take_profit'
+    STOP_LOSS = 'stop_loss_limit'
+    TAKE_PROFIT = 'take_profit_limit'
     STOP_LIMIT = 'stop_limit'
     STOP_MARKET = 'stop_market'
 
@@ -49,6 +49,8 @@ class OrderGroup(EndpointGroup):
         type_: OrderType,
         client_order_id: str=None,
         time_in_force: TimeInForce=None,
+        trigger: float=None,
+        size_percent: float=None,
     ):
         data = dict(
             market_id=market_id,
@@ -65,6 +67,12 @@ class OrderGroup(EndpointGroup):
         
         if time_in_force:
             data['time_in_force'] = time_in_force.value
+
+        if trigger:
+            data['trigger_price'] = trigger
+        
+        if size_percent:
+            data['size_percent'] = size_percent
         
         self.session.sign_request(data)
         resp = self.session.session.post(
@@ -83,7 +91,9 @@ class OrderGroup(EndpointGroup):
         order_id: int,
         market_id: str,
         price: float = None,
+        trigger: float = None,
         size: float = None,
+        size_percent: float = None,
     ):
         data = dict(
             order_id=order_id,
@@ -94,9 +104,12 @@ class OrderGroup(EndpointGroup):
         
         if size:
             data['size'] = size
-            
+        if size_percent:
+            data['size_percent'] = size_percent
         if price:
             data['price'] = price
+        if trigger:
+            data['trigger_price'] = trigger
             
         self.session.sign_request(data)
         resp = self.session.session.put(

--- a/rabbitx/client/endpoints/order.py
+++ b/rabbitx/client/endpoints/order.py
@@ -13,8 +13,10 @@ class OrderType(enum.Enum):
 
     MARKET = 'market'
     LIMIT = 'limit'
-    STOP_LOSS = 'stop_loss_limit'
-    TAKE_PROFIT = 'take_profit_limit'
+    STOP_LOSS_LIMIT = 'stop_loss_limit'
+    TAKE_PROFIT_LIMIT = 'take_profit_limit'
+    STOP_LOSS = 'stop_loss'
+    TAKE_PROFIT = 'take_profit'
     STOP_LIMIT = 'stop_limit'
     STOP_MARKET = 'stop_market'
 


### PR DESCRIPTION
This PR fixes the OrderType, OrderGroup.create and OrderType.amend to work with stoploss and take profit limit orders.

In order for them to work they require:

- the order type changed from "stop_loss" to "stop_loss_limit"  ("stop_loss" and "take_profit" do not seem to work currently)
- a "trigger_price" and "size_percent" included in the order dict when creating or amending

I have tested this on my own setup and its working as expected.